### PR TITLE
build(tests): add Microsoft.NET.StringTools dependency

### DIFF
--- a/tests/FindUnused.Tests/FindUnused.Tests.csproj
+++ b/tests/FindUnused.Tests/FindUnused.Tests.csproj
@@ -13,6 +13,7 @@
   <ItemGroup>
     <PackageReference Include="MSTest" Version="4.3.3" />
     <PackageReference Include="Microsoft.Build.Framework" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.NET.StringTools" Version="18.8.2" ExcludeAssets="runtime" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Add Microsoft.NET.StringTools to the test project dependencies to support string manipulation utilities required by the new test suite.