### PR TITLE
ci: install vsce in main workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,9 @@ jobs:
       run: dotnet test --logger "console;verbosity=detailed"
       working-directory: tests/FindUnused.Tests
 
+    - name: Install vsce
+      run: npm i -g @vscode/vsce
+
     - name: Package extension
       run: |
         # Use the tag name as part of the VSIX filename when available.


### PR DESCRIPTION
Add a step to install the `@vscode/vsce` package globally to ensure the extension packaging step has the necessary tooling available during the CI process.